### PR TITLE
Fix scorer weight calculation when no priority labels

### DIFF
--- a/server/src/scorer/index.js
+++ b/server/src/scorer/index.js
@@ -20,11 +20,12 @@ const rotundaScorer = (issue) => {
     Object.keys(PRIORITY_LABEL_WEIGHT).includes(label.name);
   const toWeight = (label) => PRIORITY_LABEL_WEIGHT[label.name] || 0;
 
-  const weight = _.max(labels.filter(byPriority).map(toWeight));
-
-  if (!weight) {
+  const priorityWeights = labels.filter(byPriority).map(toWeight);
+  if (priorityWeights.length === 0) {
     return UNSCORED;
   }
+
+  const weight = _.max(priorityWeights);
 
   const workingDays = calculateWorkingDays(issue.created_at);
   return weight * workingDays;


### PR DESCRIPTION
## Summary
- avoid negative infinity when an issue has labels but no priority label

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443e24e9d4832186282c1f1eb76315